### PR TITLE
Policy Additions: Alt accounts and "competing" servers

### DIFF
--- a/docs/public-channels/rules-and-policies.md
+++ b/docs/public-channels/rules-and-policies.md
@@ -21,6 +21,14 @@ On behalf of the staff and all our members, we're happy to have you here.  Pleas
 
 -- message break --
 
+The policies in this channel are managed and tracked through Github.  Major rewrites to the rules will increase the first (or major) number of the version number while minor additions/subtractions will increase the second number (known as a minor number).  Typographical revisions, spelling corrections, etc. will add a third (patch) number.  The rule version is always available on the less message in this channel and diffs between each version can be found on in the repository: <https://github.com/kmorris896/rapture-discord-server-documentation>
+
+Generally speaking, patches to the rules (the last kind of change), will be done through edits to the original message.  Other changes will often require a full purge and reload of the rules.  We will also let you know via a post in <#753604264147943494> that the rules have been updated.
+
++++
+
+-- message break --
+
 **__"Competing" Servers and Server Invites __**
 
 We know you have your choice of servers and we thank you for joining ours.  In order to keep membership harassment to a minimum, we ask that you refrain from advertising other BDSM servers in-channel.  We want to be supportive and encourage everyone to explore and share these other servers in established DMs.

--- a/docs/public-channels/rules-and-policies.md
+++ b/docs/public-channels/rules-and-policies.md
@@ -37,14 +37,14 @@ DMing members solely to advertise other servers is prohibited and users who rece
 
 Admins, moderators, and other staff members of these servers are respectfully requested to create a <#752172092426027108> prior to creating an introduction.  Generally speaking, there would be concern that you are here solely to recruit members to your server.  However, we also know that you may want to go some place where "you're not in charge".  All we ask is that you be honest with us so that your intentions are clear.
 
-Please note that while you are welcome here, we reserve the right to limit your interactions here.  For example, even if you verify, we may block access to verified channels.  Or we may make it so that you cannot join VC.  At current, the following restrictions are in place:
+Please note that while you are welcome here, we reserve the right to limit your interactions.  For example, even if you verify, we may block access to verified channels.  Or we may make it so that you cannot join VC.  At current, the following restrictions are in place:
 
 - Staff members, moderators, admins, unique role holders of servers that have 2K or more members are not permitted to join without admin approval.
 - Staff members, moderators, and admins of other sex toy-related servers (servers that specifically have a toy control or similar channel) must create a <#752172092426027108> prior to creating an introduction and will be required to verify.
 - Staff members, moderators, and admins of other BDSM-related servers should (but are not required) create a <#752172092426027108> prior to creating an introduction.
 - The above does not apply to "personal" servers so long as they remain private and people are invited individually and the total number of members on the server is 100 people or less.
 
-We're not asking much here and believe this balances the desire to hang out as well as maintaining transparancy.  You are welcome to use an alt account to maintain anonymitity, so long as these alts follow the policy outlined in "Alts/Multiple Accounts" below.  However, using an alt account to **circumvent** this policy is not only rude but bad form.  When creating your support ticket, please indicate that you are using an alt.  We *may* ask you verify your primary account at the discretion of the admins.  
+We're not asking much here and believe this balances the desire to hang out as well as maintaining transparancy.  You are welcome to use an alt account to maintain anonymity, so long as these alts follow the policy outlined in "Alts/Multiple Accounts" below.  However, using an alt account to **circumvent** this policy is not only rude but bad form.  When creating your support ticket, please indicate that you are using an alt.  We *may* ask you verify your primary account at the discretion of the admins.  
 
 +++
 

--- a/docs/public-channels/rules-and-policies.md
+++ b/docs/public-channels/rules-and-policies.md
@@ -42,7 +42,10 @@ Please note that while you are welcome here, we reserve the right to limit your 
 - Staff members, moderators, admins, unique role holders of servers that have 2K or more members are not permitted to join without admin approval.
 - Staff members, moderators, and admins of other sex toy-related servers (servers that specifically have a toy control or similar channel) must create a <#752172092426027108> prior to creating an introduction and will be required to verify.
 - Staff members, moderators, and admins of other BDSM-related servers should (but are not required) create a <#752172092426027108> prior to creating an introduction.
-- The above does not apply to "personal" servers so long as they remain private and people are invited individually and the total number of members on the server is 100 people or less.
+- The above does not apply to "personal" servers so long as:
+  - They are not advertised on Discord's server discovery feature, Disboard or similar website 
+  - People are invited individually, i.e. there is no generalized invite that is shared among non-friends
+  - The total number of members on the server is 100 people or less.  Personal servers
 
 We're not asking much here and believe this balances the desire to hang out as well as maintaining transparancy.  You are welcome to use an alt account to maintain anonymity, so long as these alts follow the policy outlined in "Alts/Multiple Accounts" below.  However, using an alt account to **circumvent** this policy is not only rude but bad form.  When creating your support ticket, please indicate that you are using an alt.  We *may* ask you verify your primary account at the discretion of the admins.  
 

--- a/docs/public-channels/rules-and-policies.md
+++ b/docs/public-channels/rules-and-policies.md
@@ -69,6 +69,16 @@ Please note that mods can request you re-verify at anytime.  While rare, if we s
 
 -- message break --
 
+**__Alts/Multiple Accounts__**
+
+Generally speaking, having multiple accounts (commonly referred to as alts) on this server is frowned upon.  While not completely against the rules, sometimes you want to be anonymous and want to lurk without drawing attention.  So long as your alt does not disrupt the decorm and general atmosphere of the server, you *may* have multiple accounts here.  However, if the mods believe you are using an alt to circumvent a block, or to harrass users, the mods have full discretion to take mod action against all accounts that they reasonably believe belong to you, up to and including a ban.
+
+We recommend, but do not require, registering your alt with the server staff by creating a <#752172092426027108>.  Only your main account may be verified.  In order to verify a different account, your verified account will be kicked from the server.  The mods will require you to re-verify as outlined in the "Verification" section.
+
++++
+
+-- message break --
+
 **__Breaking Rules__**
 
 Everyone here is about having a fun time.  But rule breaks are going to happen.  *Generally speaking*, members who are found to be in violation of the rules may be disciplined in one of the following methods, in order of severity:

--- a/docs/public-channels/rules-and-policies.md
+++ b/docs/public-channels/rules-and-policies.md
@@ -2,11 +2,14 @@
 layout: page
 title: "Rules and Policies"
 permalink: channel-rules-and-policies.html
+chennel.support-ticket: #752172092426027108
 ---
 
 On behalf of the staff and all our members, we're happy to have you here.  Please take a moment to read through our rules and polices.  There are a lot of them and we know you won't remember them all.  But please note that by joining our membership you agree to abide by them.  These rules written with everyone's safety and security in mind, including yours.
 
 +++
+
+-- message break --
 
 **__Policies__**
 
@@ -39,15 +42,17 @@ Admins, moderators, and other staff members of these servers are respectfully re
 
 Please note that while you are welcome here, we reserve the right to limit your interactions.  For example, even if you verify, we may block access to verified channels.  Or we may make it so that you cannot join VC.  At current, the following restrictions are in place:
 
+-- message break --
+
 - Staff members, moderators, admins, unique role holders of servers that have 2K or more members are not permitted to join without admin approval.
 - Staff members, moderators, and admins of other sex toy-related servers (servers that specifically have a toy control or similar channel) must create a <#752172092426027108> prior to creating an introduction and will be required to verify.
 - Staff members, moderators, and admins of other BDSM-related servers should (but are not required) create a <#752172092426027108> prior to creating an introduction.
 - The above does not apply to "personal" servers so long as:
-  - They are not advertised on Discord's server discovery feature, Disboard or similar website 
-  - People are invited individually, i.e. there is no generalized invite that is shared among non-friends
-  - The total number of members on the server is 100 people or less.  Personal servers
+>  - They are not advertised on Discord's server discovery feature, Disboard or similar website 
+>  - People are invited individually, i.e. there is no generalized invite that is shared among non-friends
+>  - The total number of members on the server is 100 people or less.  Personal servers
 
-We're not asking much here and believe this balances the desire to hang out as well as maintaining transparancy.  You are welcome to use an alt account to maintain anonymity, so long as these alts follow the policy outlined in "Alts/Multiple Accounts" below.  However, using an alt account to **circumvent** this policy is not only rude but bad form.  When creating your support ticket, please indicate that you are using an alt.  We *may* ask you verify your primary account at the discretion of the admins.  
+We're not asking much here and believe this balances the desire to hang out as well as maintaining transparency.  You are welcome to use an alt account to maintain anonymity, so long as these alts follow the policy outlined in "Alts/Multiple Accounts" below.  However, using an alt account to **circumvent** this policy is not only rude but bad form.  When creating your support ticket, please indicate that you are using an alt.  We *may* ask you verify your primary account at the discretion of the admins.  
 
 +++
 
@@ -194,5 +199,5 @@ All rules and policies are subject to change, but are version controlled.  It is
 
 +++
 
-This is version **1.1** and was last edited on 9/20/2020.  For details regarding changes between this version and the last version, please visit the last pull request: https://github.com/kmorris896/rapture-discord-server-documentation/pull/1
+This is version **1.1** and was last edited on 9/20/2020.  For details regarding changes between this version and the last version, please visit the last pull request: <https://github.com/kmorris896/rapture-discord-server-documentation/pull/1>
 

--- a/docs/public-channels/rules-and-policies.md
+++ b/docs/public-channels/rules-and-policies.md
@@ -154,7 +154,7 @@ But excessive thirst, especially directed at New Arrivals or Initiates without a
 
 **__Selfies__**
 
-You are welcome to post SFW selfies in <#somechannel>.  However, please follow the following rules:
+You are welcome to post SFW selfies in <#752465698391064676>.  However, please follow the following rules:
 
 - Selfies must be SFW and something you would share publicly on Facebook, LinkedIn, or other some other public social networking site.  In other words, you must be clothed appropriately.
 - No children.  Ideally, all persons in the picture should be 18+.  Please use discretion if your friends are under the age of 18.  **The mods have full authority to remove a picture they believe is not appropriate for this server.

--- a/docs/public-channels/rules-and-policies.md
+++ b/docs/public-channels/rules-and-policies.md
@@ -182,4 +182,5 @@ All rules and policies are subject to change, but are version controlled.  It is
 
 +++
 
-This is version **1.0** and was last edited on 9/14/2020.
+This is version **1.1** and was last edited on 9/20/2020.  For details regarding changes between this version and the last version, please visit the last pull request: https://github.com/kmorris896/rapture-discord-server-documentation/pull/1
+

--- a/docs/public-channels/rules-and-policies.md
+++ b/docs/public-channels/rules-and-policies.md
@@ -21,6 +21,26 @@ On behalf of the staff and all our members, we're happy to have you here.  Pleas
 
 -- message break --
 
+**__"Competing" Servers and Server Invites __**
+
+We know you have your choice of servers and we thank you for joining ours.  In order to keep membership harassment to a minimum, we ask that you refrain from advertising other BDSM servers in-channel.  We want to be supportive and encourage everyone to explore and share these other servers in established DMs.
+
+DMing members solely to advertise other servers is prohibited and users who receive such DMs should report them immediately.
+
+Admins, moderators, and other staff members of these servers are respectfully requested to create a <#752172092426027108> prior to creating an introduction.  Generally speaking, there would be concern that you are here solely to recruit members to your server.  However, we also know that you may want to go some place where "you're not in charge".  All we ask is that you be honest with us so that your intentions are clear.
+
+Please note that while you are welcome here, we reserve the right to limit your interactions here.  For example, even if you verify, we may block access to verified channels.  Or we may make it so that you cannot join VC.  At current, the following restrictions are in place:
+
+- Staff members, moderators, admins, unique role holders of servers that have 2K or more members are not permitted to join without admin approval.
+- Staff members, moderators, and admins of other sex toy-related servers (servers that specifically have a toy control or similar channel) must create a <#752172092426027108> prior to creating an introduction and will be required to verify.
+- Staff members, moderators, and admins of other BDSM-related servers should (but are not required) create a <#752172092426027108> prior to creating an introduction.
+
+We're not asking much here and believe this balances the desire to hang out as well as maintaining transparancy.  You are welcome to use an alt account to maintain anonymitity, so long as these alts follow the policy outlined in "Alts/Multiple Accounts" below.  However, using an alt account to **circumvent** this policy is not only rude but bad form.  When creating your support ticket, please indicate that you are using an alt.  We *may* ask you verify your primary account at the discretion of the admins.  
+
++++
+
+-- message break --
+
 **__Bots__**
 
 The server utilizes many bots to ease the burden of performing administrative actions.  For example, <@235148962103951360> is used to assign roles, mute and ban users, as well as keep logs of all those actions.  One specific feature of <@235148962103951360> is to log deleted and edited messages.  This server uses this feature purely for moderator actions and for investigative duties.  Although the usage of these bots are permitted through Discord's Terms of Service (See the "Your Content" section for details), it is important for you to be aware that such tools are in use on this server.

--- a/docs/public-channels/rules-and-policies.md
+++ b/docs/public-channels/rules-and-policies.md
@@ -42,6 +42,7 @@ Please note that while you are welcome here, we reserve the right to limit your 
 - Staff members, moderators, admins, unique role holders of servers that have 2K or more members are not permitted to join without admin approval.
 - Staff members, moderators, and admins of other sex toy-related servers (servers that specifically have a toy control or similar channel) must create a <#752172092426027108> prior to creating an introduction and will be required to verify.
 - Staff members, moderators, and admins of other BDSM-related servers should (but are not required) create a <#752172092426027108> prior to creating an introduction.
+- The above does not apply to "personal" servers so long as they remain private and people are invited individually and the total number of members on the server is 100 people or less.
 
 We're not asking much here and believe this balances the desire to hang out as well as maintaining transparancy.  You are welcome to use an alt account to maintain anonymitity, so long as these alts follow the policy outlined in "Alts/Multiple Accounts" below.  However, using an alt account to **circumvent** this policy is not only rude but bad form.  When creating your support ticket, please indicate that you are using an alt.  We *may* ask you verify your primary account at the discretion of the admins.  
 

--- a/docs/public-channels/rules-and-policies.md
+++ b/docs/public-channels/rules-and-policies.md
@@ -21,7 +21,7 @@ On behalf of the staff and all our members, we're happy to have you here.  Pleas
 
 -- message break --
 
-The policies in this channel are managed and tracked through Github.  Major rewrites to the rules will increase the first (or major) number of the version number while minor additions/subtractions will increase the second number (known as a minor number).  Typographical revisions, spelling corrections, etc. will add a third (patch) number.  The rule version is always available on the less message in this channel and diffs between each version can be found on in the repository: <https://github.com/kmorris896/rapture-discord-server-documentation>
+The policies in this channel are managed and tracked through Github.  Major rewrites to the rules will increase the first (or major) number of the version number while minor additions/subtractions will increase the second number (known as a minor number).  Typographical revisions, spelling corrections, etc. will add a third (patch) number.  The rule version is always available on the last message in this channel and diffs between each version can be found on in the repository: <https://github.com/kmorris896/rapture-discord-server-documentation>
 
 Generally speaking, patches to the rules (the last kind of change), will be done through edits to the original message.  Other changes will often require a full purge and reload of the rules.  We will also let you know via a post in <#753604264147943494> that the rules have been updated.
 

--- a/docs/public-channels/welcome-message.md
+++ b/docs/public-channels/welcome-message.md
@@ -35,9 +35,19 @@ When you're ready, please accept the Principles as well as <#752104497538400306>
 
 !rr add <#752074304224755755> MESSAGE_ID :white_check_mark: <@&752090021967953991>
 
+# Add the "New Arrival" Role Reaction
+
+!rr add <#752074304224755755> MESSAGE_ID :octagonal_sign: <@&752089891621568563>
+
+# Whitelist "New Arrivals" can react to this message
+
 !rr wl MESSAGE_ID <@&752089891621568563>
 
-!rr verify MESSAGE_ID
+# Make this reaction unique (can only select one)
 
-!purge 6
+!rr unique MESSAGE_ID
+
+# remove the last 8 messages
+
+!purge 8
 ```


### PR DESCRIPTION
This PR adds clarity to the github repository and includes two new policies, summarized here:

**"Sementic" versioning of the rules**: Major re-writes will increase the major number, minor adds/removes increase the minor number.  Skelling mistakes etc adds patch numbers.

**Competing Servers**: Inviting users to similar servers can only be done in DMs and must be done within established DMs.  Users joining the server to solely recruit members is against the rules.

**Alt Accounts**: Alt accounts are permitted but may only be used with permission.  Only one account can be verified at one time.

I've also updated the "#sfw-selfies" channel